### PR TITLE
fix(auth): always requires login from auth0

### DIFF
--- a/jcloud/auth.py
+++ b/jcloud/auth.py
@@ -128,7 +128,7 @@ class Auth:
 
             # TODO: add "app" parameter to API call
             async with session.get(
-                url=f'{api_host}/v2/rpc/user.identity.authorize?provider=jina-login&redirectUri={redirect_url}'
+                url=f'{api_host}/v2/rpc/user.identity.authorize?provider=jina-login&prompt=login&redirectUri={redirect_url}'
             ) as response:
                 response.raise_for_status()
                 json_response = await response.json()


### PR DESCRIPTION
This prevents automatic login and does not ask the user to login again after the user completes his/her login in the browser for the first time.