### PR TITLE
refactor: no print for log stream

### DIFF
--- a/jcloud/flow.py
+++ b/jcloud/flow.py
@@ -318,9 +318,9 @@ class CloudFlow:
         logger.debug(f'Asked to stream logs with params {params}')
 
         def dim_print(text):
-            print(f'[dim]{text}[/dim]')
+            logger.debug(f'[dim]{text}[/dim]')
 
-        log_msg = dim_print if 'request_id' in params else print
+        log_msg = dim_print if 'request_id' in params else logger.debug
 
         try:
             async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
Currently, we see the log stream output in jina now.
This pr shows the logstream only on debug level.

This will cause the logs to look like this
```
DEBUG -     INFO     -  ......
```
But since it is for debug only anyways, it would be fine.
<img width="761" alt="image" src="https://user-images.githubusercontent.com/11627845/168325235-e3527eef-863b-42c3-8b32-0f268d277f86.png">
