### PR TITLE
Log level fixes/updates

### DIFF
--- a/jcloud/__main__.py
+++ b/jcloud/__main__.py
@@ -1,4 +1,5 @@
 def main():
+    import logging
     import os
 
     from .parsers import get_main_parser
@@ -7,6 +8,8 @@ def main():
 
     if args.loglevel:
         os.environ['JCLOUD_LOGLEVEL'] = args.loglevel
+
+    logging.getLogger('asyncio').setLevel(logging.WARNING)
 
     try:
         if 'NO_VERSION_CHECK' not in os.environ:

--- a/jcloud/constants.py
+++ b/jcloud/constants.py
@@ -1,0 +1,30 @@
+from enum import Enum
+
+
+WOLF_API = 'https://api.wolf.jina.ai/dev/flows'
+LOGSTREAM_API = 'wss://logs.wolf.jina.ai/dev'
+ARTIFACT_API = 'https://apihubble.jina.ai/v2/rpc/artifact.upload'
+
+
+class Status(str, Enum):
+    SUBMITTED = 'SUBMITTED'
+    NORMALIZING = 'NORMALIZING'
+    NORMALIZED = 'NORMALIZED'
+    STARTING = 'STARTING'
+    FAILED = 'FAILED'
+    ALIVE = 'ALIVE'
+    UPDATING = 'UPDATING'
+    DELETING = 'DELETING'
+    DELETED = 'DELETED'
+
+    @property
+    def streamable(self) -> bool:
+        return self in (Status.ALIVE, Status.UPDATING, Status.DELETING)
+
+    @property
+    def alive(self) -> bool:
+        return self == Status.ALIVE
+
+    @property
+    def deleted(self) -> bool:
+        return self == Status.DELETED

--- a/jcloud/flow.py
+++ b/jcloud/flow.py
@@ -12,41 +12,15 @@ from typing import Dict, List, Optional
 import aiohttp
 from rich import print
 
+from .constants import WOLF_API, LOGSTREAM_API, ARTIFACT_API, Status
 from .helper import get_logger, get_or_reuse_loop, get_pbar, normalized, zipdir
 
-WOLF_API = 'https://api.wolf.jina.ai/dev/flows'
-LOGSTREAM_API = 'wss://logs.wolf.jina.ai/dev'
-ARTIFACT_API = 'https://apihubble.jina.ai/v2/rpc/artifact.upload'
 
 logger = get_logger()
 
 pbar, pb_task = get_pbar(
     '', total=5, disable='JCLOUD_NO_PROGRESSBAR' in os.environ
 )  # progress bar for deployment
-
-
-class Status(str, Enum):
-    SUBMITTED = 'SUBMITTED'
-    NORMALIZING = 'NORMALIZING'
-    NORMALIZED = 'NORMALIZED'
-    STARTING = 'STARTING'
-    FAILED = 'FAILED'
-    ALIVE = 'ALIVE'
-    UPDATING = 'UPDATING'
-    DELETING = 'DELETING'
-    DELETED = 'DELETED'
-
-    @property
-    def streamable(self) -> bool:
-        return self in (Status.ALIVE, Status.UPDATING, Status.DELETING)
-
-    @property
-    def alive(self) -> bool:
-        return self == Status.ALIVE
-
-    @property
-    def deleted(self) -> bool:
-        return self == Status.DELETED
 
 
 def _exit_if_response_error(response, expected_status):

--- a/jcloud/flow.py
+++ b/jcloud/flow.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import os
 from contextlib import suppress
 from dataclasses import dataclass
@@ -333,7 +334,10 @@ class CloudFlow:
                         async for msg in ws:
                             if msg.type == aiohttp.http.WSMsgType.TEXT:
                                 log_dict: Dict = msg.json()
-                                if log_dict.get('status') == 'STREAMING':
+                                if (
+                                    log_dict.get('status') == 'STREAMING'
+                                    and logger.getEffectiveLevel() < logging.INFO
+                                ):
                                     log_msg(log_dict['message'])
                     logger.debug(f'Disconnected from the logstream server ...')
                 except aiohttp.WSServerHandshakeError as e:

--- a/jcloud/parsers/list.py
+++ b/jcloud/parsers/list.py
@@ -2,7 +2,7 @@ from .base import set_base_parser
 
 
 def set_list_parser(parser=None):
-    from ..flow import Status
+    from ..constants import Status
 
     if not parser:
         parser = set_base_parser()


### PR DESCRIPTION
## Changes ##

- Set the default loglevel to `INFO`.
- Removed debug logging from `asyncio`, i.e., the logs start with `Using selector..`.
- Streamed logs from WOLF now won't print if the log level is above `DEBUG`.
- fixed `--loglevel` option; the CLI wasn't respecting the input, because in `get_main_parser`, the `get_logger` was first imported by `set_list_parser`, which was **before** we set `os.environ['JCLOUD_LOGLEVEL']` in `__main__.py`, which means the input not respected. I introduced a new module `constants.py` so the `get_logger` will only be imported after the env set.

Here are new UX (`INFO` being the default, but with `--loglevel DEBUG` we get to see more):

<img width="791" alt="Screen Shot 2022-05-17 at 14 36 47" src="https://user-images.githubusercontent.com/2687065/168746170-25e74d61-6691-4155-a811-28fa42b42b04.png">

