### PR TITLE
refactor: handle errors from jc status more gracefully

### DIFF
--- a/jcloud/api.py
+++ b/jcloud/api.py
@@ -38,15 +38,22 @@ async def status(args):
     console = Console(highlighter=CustomHighlighter())
     with console.status(f'[bold]Fetching status of {args.flow}...'):
         _result = await CloudFlow(flow_id=args.flow).status
-        for k, v in _result.items():
-            if k == 'yaml' and v is not None:
-                v = Syntax(v, 'yaml', theme='monokai', line_numbers=True, code_width=40)
-            elif k == 'envs' and v:
-                v = JSON(json.dumps(v))
-            else:
-                v = str(v)
-            _t.add_row(k, v)
-        console.print(_t)
+        if not _result:
+            console.print(
+                f'[red]Something went wrong while fetching the details for {args.flow} ![/red]. Please retry after sometime.'
+            )
+        else:
+            for k, v in _result.items():
+                if k == 'yaml' and v is not None:
+                    v = Syntax(
+                        v, 'yaml', theme='monokai', line_numbers=True, code_width=40
+                    )
+                elif k == 'envs' and v:
+                    v = JSON(json.dumps(v))
+                else:
+                    v = str(v)
+                _t.add_row(k, v)
+            console.print(_t)
 
 
 @asyncify


### PR DESCRIPTION
Currently `jc status` doesn't handle errors from wolf gracefully, i.e., the unexpected errors causing `_result` to be `None`:

<img width="1143" alt="Screen Shot 2022-05-18 at 13 10 05" src="https://user-images.githubusercontent.com/2687065/168962283-f7e3e744-173f-4494-8a32-121d2ac53425.png">
 
This PR improved it by taking care of the `None`, the message is open to change:

<img width="345" alt="Screen Shot 2022-05-18 at 14 08 48" src="https://user-images.githubusercontent.com/2687065/168969082-9f898586-8241-4798-a9f4-b21c2acdad12.png">


