### PR TITLE
fix: show name in deploy message

### DIFF
--- a/jcloud/flow.py
+++ b/jcloud/flow.py
@@ -353,7 +353,7 @@ class CloudFlow:
                 pb_task,
                 advance=1,
                 description='Submitting',
-                title=f'Deploying {Path(self.path).resolve()}',
+                title=f'Deploying {self.name or Path(self.path).resolve()}',
             )
             await self._deploy()
             pbar.update(pb_task, description='Queueing (can take ~1 minute)', advance=1)


### PR DESCRIPTION
Fixes #35 

Without name:
![image](https://user-images.githubusercontent.com/9050737/170481449-66e564b6-71a3-4a05-90bf-2e5cd919eef7.png)

With name:
![image](https://user-images.githubusercontent.com/9050737/170481530-9242cd47-f1ba-4c47-8dce-d5b2d49929bf.png)
