### PR TITLE
ci: make log level to be DEBUG when running pytest in ci/cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,7 +46,7 @@ jobs:
         id: test
         run: |
           pytest --suppress-no-test-exit-code --cov=jcloud --cov-report=xml \
-            -v -s -m "not gpu" ${{ matrix.test-path }}
+            -v -s --log-cli-level=DEBUG -m "not gpu" ${{ matrix.test-path }}
           echo "::set-output name=codecov_flag::jcloud"
         timeout-minutes: 30
       - name: Check codecov file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         id: test
         run: |
           pytest --suppress-no-test-exit-code --cov=jcloud --cov-report=xml \
-            -v -s -m "not gpu" ${{ matrix.test-path }}
+            -v -s --log-cli-level=DEBUG -m "not gpu" ${{ matrix.test-path }}
           echo "::set-output name=codecov_flag::jcloud"
         timeout-minutes: 30
         env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -57,7 +57,7 @@ jobs:
           export JCLOUD_LOGLEVEL=DEBUG
           export JCLOUD_NO_SURVEY=1
           pytest --suppress-no-test-exit-code --cov=jcloud --cov-report=xml \
-            -v -s -m "not gpu" ${{ matrix.test-path }}
+            -v -s --log-cli-level=DEBUG -m "not gpu" ${{ matrix.test-path }}
           echo "::set-output name=codecov_flag::jcloud"
         timeout-minutes: 30
       - name: Check codecov file


### PR DESCRIPTION
**Goal**
This is to fix the situation where debug logs aren't printed in CI/CD.
Ref: https://stackoverflow.com/questions/4673373/logging-within-pytest-tests.

Test new run after applying this fix:
https://github.com/jina-ai/jcloud/runs/6649703435?check_suite_focus=true.
As you can see the debug loggings were also printed.

- [x] Run [Integration tests GHA](https://github.com/jina-ai/jcloud/actions/workflows/integration-tests.yml) manually & comment the link.

@jina-ai/team-wolf 
