### PR TITLE
test: skip test_executors_from_external_sources for now

### DIFF
--- a/tests/integration/test_executors_from_external_sources.py
+++ b/tests/integration/test_executors_from_external_sources.py
@@ -7,6 +7,9 @@ from jina import Client, Document
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
+@pytest.mark.skip(
+    reason="This test is currently not reliable due to https://github.com/jina-ai/jcloud/issues/45"
+)
 def test_executors_from_external_sources():
     FLOW_FILE_PATH = os.path.join(
         cur_dir, "flows", "executors-from-external-sources.yml"


### PR DESCRIPTION
**Goal**
This test is currently not reliable due to https://github.com/jina-ai/jcloud/issues/45.

- [ ] Run [Integration tests GHA](https://github.com/jina-ai/jcloud/actions/workflows/integration-tests.yml) manually & comment the link.

@jina-ai/team-wolf 
