### PR TITLE
test: undo external source integration test skip

### DIFF
--- a/tests/integration/test_executors_from_external_sources.py
+++ b/tests/integration/test_executors_from_external_sources.py
@@ -7,9 +7,6 @@ from jina import Client, Document
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
-@pytest.mark.skip(
-    reason="This test is currently not reliable due to https://github.com/jina-ai/jcloud/issues/45"
-)
 def test_executors_from_external_sources():
     FLOW_FILE_PATH = os.path.join(
         cur_dir, "flows", "executors-from-external-sources.yml"


### PR DESCRIPTION
**Goal**
Now that [this issue](https://github.com/jina-ai/jcloud/issues/45) is fixed, let's undo the test skip.

- [x] Run [Integration tests GHA](https://github.com/jina-ai/jcloud/actions/workflows/integration-tests.yml) manually & comment the link.
Link: https://github.com/jina-ai/jcloud/actions/runs/2445866771

@jina-ai/team-wolf 
