### PR TITLE
test: add integration test to cover wolf's jina version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,19 +278,6 @@ executors:
 <img src=".github/README-img/external-executors-multiple.png" width="50%">
 </p>
 
-#### Deploy with specific `jina` version
-
-When deploying Flow to `jcloud`, the default `jina` version would be used. If for any reason you'd like your Flow to be built with a specific `jina` version, you can do so by using `version` arg while deploying the Flow.
-
-```yaml
-jtype: Flow
-jcloud:
-  version: 3.4.11
-executors:
-  - name: custom
-    uses: jinahub+docker://CustomExecutor
-```
-
 ## FAQ
 
 - **Why does it take a while on every operation of `jcloud`?**

--- a/README.md
+++ b/README.md
@@ -278,6 +278,19 @@ executors:
 <img src=".github/README-img/external-executors-multiple.png" width="50%">
 </p>
 
+#### Deploy with specific `jina` version
+
+When deploying Flow to `jcloud`, the default `jina` version would be used. If for any reason you'd like your Flow to be built with a specific `jina` version, you can do so by using `version` arg while deploying the Flow.
+
+```yaml
+jtype: Flow
+jcloud:
+  version: 3.4.11
+executors:
+  - name: custom
+    uses: jinahub+docker://CustomExecutor
+```
+
 ## FAQ
 
 - **Why does it take a while on every operation of `jcloud`?**

--- a/tests/integration/flows/expose-version-arg.yml
+++ b/tests/integration/flows/expose-version-arg.yml
@@ -1,0 +1,10 @@
+jtype: Flow
+with:
+  protocol: http
+jcloud:
+  version: 3.4.11
+executors:
+  - name: sentencizer
+    uses: jinahub+docker://Sentencizer
+    env:
+      JINA_LOG_LEVEL : DEBUG

--- a/tests/integration/test_expose_version_arg.py
+++ b/tests/integration/test_expose_version_arg.py
@@ -1,0 +1,16 @@
+import os
+
+import pytest
+from jcloud.flow import CloudFlow
+from jina import Client, Document
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_expose_version_arg():
+    FLOW_FILE_PATH = os.path.join(cur_dir, "flows", "expose-version-arg.yml")
+    with CloudFlow(path=FLOW_FILE_PATH, name="expose-version-arg") as flow:
+        da = Client(host=flow.gateway).post(
+            on="/", inputs=Document(text="Hello. World.")
+        )
+        assert da[0].chunks[0].text == "Hello." and da[0].chunks[1].text == "World."


### PR DESCRIPTION
**Goal**

A part of https://github.com/jina-ai/wolf/issues/117, we need to make sure e2e tests starting from client side cover the new feature as well. 

- [ ] Run [Integration tests GHA](https://github.com/jina-ai/jcloud/actions/workflows/integration-tests.yml) manually & comment the link.

@jina-ai/team-wolf 
