### PR TITLE
fix: list render, jcloud dependencies and jcloud logging

### DIFF
--- a/jcloud/api.py
+++ b/jcloud/api.py
@@ -87,22 +87,11 @@ async def _list_by_status(status):
     ):
         _result = await CloudFlow().list_all(status=status)
         if _result:
-            has_external_executors = any(
-                [
-                    k['gateway'] is None and k.get('endpoints') is not None
-                    for k in _result
-                ]
-            )
             for k in _result:
                 if k['gateway'] is None and k.get('endpoints') is not None:
                     _endpoint = json.dumps(k['endpoints'], indent=2, sort_keys=True)
                 else:
-                    if has_external_executors:
-                        _endpoint = json.dumps(
-                            {'gateway': k['gateway']}, indent=2, sort_keys=True
-                        )
-                    else:
-                        _endpoint = k['gateway']
+                    _endpoint = k['gateway']
                 _t.add_row(
                     k['id'].split('-')[-1],
                     k['status'],

--- a/jcloud/api.py
+++ b/jcloud/api.py
@@ -76,7 +76,7 @@ async def _list_by_status(status):
             return dt
 
     _t = Table(
-        'ID', 'Status', 'Gateway', 'Created (UTC)', box=box.ROUNDED, highlight=True
+        'ID', 'Status', 'Endpoint(s)', 'Created (UTC)', box=box.ROUNDED, highlight=True
     )
 
     console = Console(highlighter=CustomHighlighter())
@@ -89,13 +89,13 @@ async def _list_by_status(status):
         if _result:
             for k in _result:
                 if k['gateway'] is None and k.get('endpoints') is not None:
-                    _endpoint = k['endpoints']
+                    _endpoint_data = k['endpoints']
                 else:
-                    _endpoint = k['gateway']
+                    _endpoint_data = {'gateway': k['gateway']}
                 _t.add_row(
                     k['id'].split('-')[-1],
                     k['status'],
-                    _endpoint,
+                    json.dumps(_endpoint_data, indent=2, sort_keys=True),
                     cleanup(k['ctime']),
                 )
             console.print(_t)

--- a/jcloud/api.py
+++ b/jcloud/api.py
@@ -87,15 +87,26 @@ async def _list_by_status(status):
     ):
         _result = await CloudFlow().list_all(status=status)
         if _result:
+            has_external_executors = any(
+                [
+                    k['gateway'] is None and k.get('endpoints') is not None
+                    for k in _result
+                ]
+            )
             for k in _result:
                 if k['gateway'] is None and k.get('endpoints') is not None:
-                    _endpoint_data = k['endpoints']
+                    _endpoint = json.dumps(k['endpoints'], indent=2, sort_keys=True)
                 else:
-                    _endpoint_data = {'gateway': k['gateway']}
+                    if has_external_executors:
+                        _endpoint = json.dumps(
+                            {'gateway': k['gateway']}, indent=2, sort_keys=True
+                        )
+                    else:
+                        _endpoint = k['gateway']
                 _t.add_row(
                     k['id'].split('-')[-1],
                     k['status'],
-                    json.dumps(_endpoint_data, indent=2, sort_keys=True),
+                    _endpoint,
                     cleanup(k['ctime']),
                 )
             console.print(_t)

--- a/jcloud/flow.py
+++ b/jcloud/flow.py
@@ -422,7 +422,7 @@ class CloudFlow:
         )
         my_table.add_row('ID', self.id)
         if self.gateway is not None:
-            my_table.add_row('Gateway', self.gateway)
+            my_table.add_row('Endpoint(s)', self.gateway)
         elif self.endpoints:
             for k, v in self.endpoints.items():
                 my_table.add_row(k, v)

--- a/jcloud/helper.py
+++ b/jcloud/helper.py
@@ -76,6 +76,8 @@ def get_logger(name='jcloud'):
     logger = logging.getLogger(name)
     logger.setLevel(os.environ.get('JCLOUD_LOGLEVEL', 'INFO'))
 
+    if logger.hasHandlers():
+        logger.handlers.clear()
     rich_handler = RichHandler(rich_tracebacks=True)
     formatter = logging.Formatter('%(message)s')
     rich_handler.setFormatter(formatter)

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,13 @@ setup(
     long_description_content_type='text/markdown',
     zip_safe=False,
     setup_requires=['setuptools>=18.0', 'wheel'],
-    install_requires=['rich>=12.0.0', 'aiohttp>=3.8.0', 'pyyaml', 'python-dotenv'],
+    install_requires=[
+        'rich>=12.0.0',
+        'aiohttp>=3.8.0',
+        'packaging',
+        'pyyaml',
+        'python-dotenv',
+    ],
     extras_require={
         'test': [
             'pytest',


### PR DESCRIPTION
**Goal**

- Previously for `expose_gateway=False` flows, the parsing was incorrect in list view.
ref:  https://jinaai.slack.com/archives/C03F1BG5VMW/p1655087874560469

```
  File "/Users/zacli/Code/jcloud/jcloud/api.py", line 109, in list
    await _list_by_status(args.status)
  File "/Users/zacli/Code/jcloud/jcloud/api.py", line 101, in _list_by_status
    cleanup(k['ctime']),
  File "/Users/zacli/Code/jcloud/37_env/lib/python3.7/site-packages/rich-12.4.4-py3.7.egg/rich/table.py", line 461, in add_row
    f"unable to render {type(renderable).__name__}; a string or other renderable object is required"
rich.errors.NotRenderableError: unable to render dict; a string or other renderable object is required
```
- Added `packaging` dependency and removed `jina` dependency in `env_helper` so that we don't have dependency requirement in env that doesn't have `jina`/`packaging` installed.
- Also fixed the logger messages duplication issue by clearing the handlers before adding logging handlers, so now we don't have duplicated logs from the client ([ref](https://stackoverflow.com/questions/7173033/duplicate-log-output-when-using-python-logging-module)). 

Here's the proposed fix after talking with @deepankarm regarding the list command UX:

<img width="821" alt="Screen Shot 2022-06-17 at 16 18 15" src="https://user-images.githubusercontent.com/2687065/174257516-01cca25b-96e8-4d58-bbfa-0082c6d23dc9.png">

Integration tests: https://github.com/jina-ai/jcloud/actions/runs/2526347460

- [x] Run [Integration tests GHA](https://github.com/jina-ai/jcloud/actions/workflows/integration-tests.yml) manually & comment the link.

@jina-ai/team-wolf 
