### PR TITLE
fix(api): fix the bug in listing multi-endpoints flows

### DIFF
--- a/jcloud/api.py
+++ b/jcloud/api.py
@@ -71,7 +71,10 @@ def _get_status_table(result):
 
     from rich import box
     from rich.table import Table
-    t = Table('ID', 'Status', 'Gateway', 'Created (UTC)', box=box.ROUNDED, highlight=True)
+
+    t = Table(
+        'ID', 'Status', 'Gateway', 'Created (UTC)', box=box.ROUNDED, highlight=True
+    )
     for k in result:
         if k['gateway'] is None and k.get('endpoints') is not None:
             for idx, (ep_name, ep_url) in enumerate(k['endpoints'].items()):
@@ -82,18 +85,10 @@ def _get_status_table(result):
                     id_str = k['id'].split('-')[-1]
                     status_str = k['status']
                     ctime_str = cleanup(k['ctime'])
-                t.add_row(
-                    id_str,
-                    status_str,
-                    ep_url,
-                    ctime_str
-                )
+                t.add_row(id_str, status_str, ep_url, ctime_str)
         else:
             t.add_row(
-                k['id'].split('-')[-1],
-                k['status'],
-                k['gateway'],
-                cleanup(k['ctime'])
+                k['id'].split('-')[-1], k['status'], k['gateway'], cleanup(k['ctime'])
             )
     return t
 

--- a/jcloud/api.py
+++ b/jcloud/api.py
@@ -58,41 +58,6 @@ async def status(args):
             console.print(_t)
 
 
-def _get_status_table(result):
-    from datetime import datetime
-
-    def cleanup(dt) -> str:
-        try:
-            return datetime.strptime(dt, '%Y-%m-%dT%H:%M:%S.%f%z').strftime(
-                '%d-%b-%Y %H:%M'
-            )
-        except:
-            return dt
-
-    from rich import box
-    from rich.table import Table
-
-    t = Table(
-        'ID', 'Status', 'Gateway', 'Created (UTC)', box=box.ROUNDED, highlight=True
-    )
-    for k in result:
-        if k['gateway'] is None and k.get('endpoints') is not None:
-            for idx, (ep_name, ep_url) in enumerate(k['endpoints'].items()):
-                id_str = ''
-                status_str = ''
-                ctime_str = ''
-                if idx == 0:
-                    id_str = k['id'].split('-')[-1]
-                    status_str = k['status']
-                    ctime_str = cleanup(k['ctime'])
-                t.add_row(id_str, status_str, ep_url, ctime_str)
-        else:
-            t.add_row(
-                k['id'].split('-')[-1], k['status'], k['gateway'], cleanup(k['ctime'])
-            )
-    return t
-
-
 async def _list_by_status(status):
 
     from rich.console import Console
@@ -260,3 +225,38 @@ def survey(args):
     from .auth import Survey
 
     Survey().ask(-1)
+
+
+def _get_status_table(result):
+    from datetime import datetime
+
+    def cleanup(dt) -> str:
+        try:
+            return datetime.strptime(dt, '%Y-%m-%dT%H:%M:%S.%f%z').strftime(
+                '%d-%b-%Y %H:%M'
+            )
+        except:
+            return dt
+
+    from rich import box
+    from rich.table import Table
+
+    t = Table(
+        'ID', 'Status', 'Gateway', 'Created (UTC)', box=box.ROUNDED, highlight=True
+    )
+    for k in result:
+        if k['gateway'] is None and k.get('endpoints') is not None:
+            for idx, (ep_name, ep_url) in enumerate(k['endpoints'].items()):
+                id_str = ''
+                status_str = ''
+                ctime_str = ''
+                if idx == 0:
+                    id_str = k['id'].split('-')[-1]
+                    status_str = k['status']
+                    ctime_str = cleanup(k['ctime'])
+                t.add_row(id_str, status_str, ep_url, ctime_str)
+        else:
+            t.add_row(
+                k['id'].split('-')[-1], k['status'], k['gateway'], cleanup(k['ctime'])
+            )
+    return t

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,8 +1,9 @@
 import os
+import pytest
 
 from unittest.mock import Mock, patch, call
 
-from jcloud.api import remove
+from jcloud.api import remove, _get_status_table
 
 
 async def mock_aexit(*args, **kwargs):
@@ -36,7 +37,7 @@ def test_remove_single(mock_cloudflow):
 @patch('jcloud.api._terminate_flow_simplified')
 @patch('jcloud.api._list_by_status')
 def test_remove_selected_multi(
-    mock_list_by_status, mock_terminate_flow_simplified, mock_ask
+        mock_list_by_status, mock_terminate_flow_simplified, mock_ask
 ):
     args = Mock()
     args.flows = ['flow_1', 'flow_2']
@@ -76,3 +77,28 @@ def test_non_interative(mock_list_by_status, mock_terminate_flow_simplified):
     mock_terminate_flow_simplified.assert_has_calls(
         [call('flow1'), call('flow2'), call('flow3')]
     )
+
+
+@pytest.mark.parametrize('result', [
+    [{
+        'id': 'jflow-d8938ca2f3',
+        'ctime': '2022-06-14T23:54:42.243000+00:00',
+        'status': 'ALIVE',
+        'gateway': 'https://nan-wang-docarray-d8938ca2f3.wolf.jina.ai',
+        'endpoints': {
+            'gateway': 'https://nan-wang-docarray-d8938ca2f3.wolf.jina.ai'
+        }
+    }, ], [{
+        'id': 'jflow-4ee8e43ec7',
+        'ctime': '2022-06-14T18:26:39.818000+00:00',
+        'status': 'ALIVE',
+        'gateway': None,
+        'endpoints': {
+            'questionfilterer': 'grpcs://questionfilterer-3h-4ee8e43ec7.wolf.jina.ai',
+            'logger': 'grpcs://logger-pn-4ee8e43ec7.wolf.jina.ai'}
+    }, ]])
+def test__get_status_table(result):
+    try:
+        _get_status_table(result)
+    except Exception:
+        assert False, 'failed to create status table'

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -37,7 +37,7 @@ def test_remove_single(mock_cloudflow):
 @patch('jcloud.api._terminate_flow_simplified')
 @patch('jcloud.api._list_by_status')
 def test_remove_selected_multi(
-        mock_list_by_status, mock_terminate_flow_simplified, mock_ask
+    mock_list_by_status, mock_terminate_flow_simplified, mock_ask
 ):
     args = Mock()
     args.flows = ['flow_1', 'flow_2']
@@ -79,24 +79,34 @@ def test_non_interative(mock_list_by_status, mock_terminate_flow_simplified):
     )
 
 
-@pytest.mark.parametrize('result', [
-    [{
-        'id': 'jflow-d8938ca2f3',
-        'ctime': '2022-06-14T23:54:42.243000+00:00',
-        'status': 'ALIVE',
-        'gateway': 'https://nan-wang-docarray-d8938ca2f3.wolf.jina.ai',
-        'endpoints': {
-            'gateway': 'https://nan-wang-docarray-d8938ca2f3.wolf.jina.ai'
-        }
-    }, ], [{
-        'id': 'jflow-4ee8e43ec7',
-        'ctime': '2022-06-14T18:26:39.818000+00:00',
-        'status': 'ALIVE',
-        'gateway': None,
-        'endpoints': {
-            'questionfilterer': 'grpcs://questionfilterer-3h-4ee8e43ec7.wolf.jina.ai',
-            'logger': 'grpcs://logger-pn-4ee8e43ec7.wolf.jina.ai'}
-    }, ]])
+@pytest.mark.parametrize(
+    'result',
+    [
+        [
+            {
+                'id': 'jflow-d8938ca2f4',
+                'ctime': '2022-06-14T23:54:42.243000+00:00',
+                'status': 'ALIVE',
+                'gateway': 'https://nan-wang-docarray-d8938ca2f3.wolf.jina.ai',
+                'endpoints': {
+                    'gateway': 'https://nan-wang-docarray-d8938ca2f3.wolf.jina.ai'
+                },
+            },
+        ],
+        [
+            {
+                'id': 'jflow-4ee8e43ec7',
+                'ctime': '2022-06-14T18:26:39.818000+00:00',
+                'status': 'ALIVE',
+                'gateway': None,
+                'endpoints': {
+                    'questionfilterer': 'grpcs://questionfilterer-3h-4ee8e43ec7.wolf.jina.ai',
+                    'logger': 'grpcs://logger-pn-4ee8e43ec7.wolf.jina.ai',
+                },
+            },
+        ],
+    ],
+)
 def test__get_status_table(result):
     try:
         _get_status_table(result)


### PR DESCRIPTION
**Goal**
fix the bug in listing multi-endpoints flows

- [ ] Run [Integration tests GHA](https://github.com/jina-ai/jcloud/actions/workflows/integration-tests.yml) manually & comment the link.

When the flow has multiple endpoints, `jc list` will lead to the following error
```bash
(docsqa) ➜  src git:(fix-faq-filter-738) ✗ jc list
Traceback (most recent call last):
  File "/Users/nanwang/Codes/jina-ai/docsQA/docsqa/bin/jc", line 8, in <module>
    sys.exit(main())
  File "/Users/nanwang/Codes/jina-ai/docsQA/docsqa/lib/python3.8/site-packages/jcloud/__main__.py", line 21, in main
    getattr(api, args.cli.replace('-', '_'))(args)
  File "/Users/nanwang/Codes/jina-ai/docsQA/docsqa/lib/python3.8/site-packages/jcloud/api.py", line 13, in wrapper
    return asyncio.run(f(*args, **kwargs))
  File "/Users/nanwang/.pyenv/versions/3.8.9/lib/python3.8/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Users/nanwang/.pyenv/versions/3.8.9/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/Users/nanwang/Codes/jina-ai/docsQA/docsqa/lib/python3.8/site-packages/jcloud/api.py", line 107, in list
    await _list_by_status(args.status)
  File "/Users/nanwang/Codes/jina-ai/docsQA/docsqa/lib/python3.8/site-packages/jcloud/api.py", line 95, in _list_by_status
    _t.add_row(
  File "/Users/nanwang/Codes/jina-ai/docsQA/docsqa/lib/python3.8/site-packages/rich/table.py", line 460, in add_row
    raise errors.NotRenderableError(
rich.errors.NotRenderableError: unable to render dict; a string or other renderable object is required
```
