### PR TITLE
feat: add handle for displaying dashboards in jc status

### DIFF
--- a/jcloud/flow.py
+++ b/jcloud/flow.py
@@ -12,7 +12,14 @@ import aiohttp
 from rich import print
 
 from .constants import ARTIFACT_API, LOGSTREAM_API, WOLF_API, Status
-from .helper import get_logger, get_or_reuse_loop, get_pbar, normalized, zipdir
+from .helper import (
+    get_logger,
+    get_or_reuse_loop,
+    get_pbar,
+    prepare_flow_model_for_render,
+    normalized,
+    zipdir,
+)
 
 logger = get_logger()
 
@@ -192,7 +199,9 @@ class CloudFlow:
                     url=f'{WOLF_API}/{self.flow_id}', headers=self.auth_header
                 ) as response:
                     response.raise_for_status()
-                    return await response.json()
+                    _results = await response.json()
+                    prepare_flow_model_for_render(_results)
+                    return _results
         except aiohttp.ClientResponseError as e:
             if e.status == HTTPStatus.UNAUTHORIZED:
                 _exit_error(

--- a/jcloud/helper.py
+++ b/jcloud/helper.py
@@ -201,3 +201,19 @@ class CustomHighlighter(ReprHighlighter):
 
 def remove_prefix(s: str, prefix: str):
     return s[len(prefix) :] if s.startswith(prefix) else s
+
+
+def prepare_flow_model_for_render(response: Dict) -> None:
+    # 'gateway' and 'endpoints' should be mutually exclusive.
+    if response['gateway']:
+        del response['endpoints']
+    elif response['endpoints']:
+        del response['gateway']
+
+    if response['dashboards']:
+        # Extra handle for 'dashboards' key; the value is a map
+        # but since we only have monitoring dashboard at the moment,
+        # for simplicity we turn the map to a string for display purpose.
+        response['dashboards'] = response['dashboards']['monitoring']
+    else:
+        del response['dashboards']

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from jcloud.helper import normalized
+from jcloud.helper import normalized, prepare_flow_model_for_render
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -41,3 +41,33 @@ def test_normalized(filename, envs):
 )
 def test_not_normalized(filename, envs):
     assert not normalized(os.path.join(cur_dir, 'flows', 'not', filename), envs)
+
+
+@pytest.mark.parametrize(
+    'response, expected',
+    (
+        (
+            {
+                'endpoints': 'something_can_be_ignored',
+                'gateway': 'abc',
+                'dashboards': None,
+            },
+            {'gateway': 'abc'},
+        ),
+        (
+            {'endpoints': 'abc', 'gateway': None, 'dashboards': None},
+            {'endpoints': 'abc'},
+        ),
+        (
+            {
+                'dashboards': {'monitoring': 'abc'},
+                'gateway': 'abc',
+                'endpoints': 'something_can_be_ignored',
+            },
+            {'dashboards': 'abc', 'gateway': 'abc'},
+        ),
+    ),
+)
+def test_prepare_flow_model_for_render(response, expected):
+    prepare_flow_model_for_render(response)
+    assert response == expected


### PR DESCRIPTION
Extra handle for 'dashboards' key; the value is a map but since we only have monitoring dashboard at the moment,
for simplicity we turn the map to a string for display purpose.

Now for Flow that has have monitoring turned on:
<img width="448" alt="Screen Shot 2022-07-04 at 17 39 41" src="https://user-images.githubusercontent.com/2687065/177128351-89bad872-6e66-45e4-8242-b164d381f19d.png">

Flow that doesn't have monitoring turned on (`dashboards` would be hidden):
<img width="426" alt="Screen Shot 2022-07-04 at 17 40 18" src="https://user-images.githubusercontent.com/2687065/177128384-e91022ae-9361-4406-9f53-540a5402196a.png">

Additional I also added logic to make sure we don't show `endpoints` and `gateway` at the same way which might confuses user.

- [x] Run [Integration tests GHA](https://github.com/jina-ai/jcloud/actions/workflows/integration-tests.yml) manually & comment the link: https://github.com/jina-ai/jcloud/actions/runs/2608872776

@jina-ai/team-wolf 
