### PR TITLE
feat: add knative support and test

### DIFF
--- a/jcloud/helper.py
+++ b/jcloud/helper.py
@@ -168,6 +168,7 @@ def valid_uri(uses):
             'docker',
             'jinahub+docker',
             'jinahub+sandbox',
+            'jinahub+serverless',
             'jinahub',
         )
     except Exception:

--- a/tests/integration/flows/executors-autoscaled.yml
+++ b/tests/integration/flows/executors-autoscaled.yml
@@ -1,0 +1,18 @@
+jtype: Flow
+with:
+  protocol: http
+  monitoring: true
+jcloud:
+  gateway:
+    type: kong
+executors:
+  - name: auto1
+    uses: jinahub+docker://Sentencizer
+    jcloud:
+      autoscale: 
+        min: 1
+        max: 2
+        metric: rps
+        target: 2
+  - name: auto2
+    uses: jinahub+serverless://Sentencizer

--- a/tests/integration/test_executors_autoscaled.py
+++ b/tests/integration/test_executors_autoscaled.py
@@ -1,0 +1,15 @@
+import os
+
+from jcloud.flow import CloudFlow
+from jina import Client, Document
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_customized_resources():
+    FLOW_FILE_PATH = os.path.join(cur_dir, "flows", "executors-autoscaled.yml")
+    with CloudFlow(path=FLOW_FILE_PATH, name="executors-autoscaled") as flow:
+        da = Client(host=flow.gateway).post(
+            on="/", inputs=Document(text="Hello. World.")
+        )
+        assert da[0].chunks[0].text == "Hello." and da[0].chunks[1].text == "World."


### PR DESCRIPTION
## Context ##

To make `jinahub+serverless` protocol work, we need to accept it in `jc` (`CloudFlow`), otherwise it would think it's not a valid URL and make the deployment go to normalization route instead.

I'm also adding integration test to cover knative case.

Integration tests (passed): https://github.com/jina-ai/jcloud/actions/runs/2829973362