### PR TITLE
feat: allow extending cli parser with jcloud cli

### DIFF
--- a/jcloud/__main__.py
+++ b/jcloud/__main__.py
@@ -18,7 +18,7 @@ def main():
             is_latest_version()
         from jcloud import api
 
-        getattr(api, args.cli.replace('-', '_'))(args)
+        getattr(api, args.jc_cli.replace('-', '_'))(args)
     except KeyboardInterrupt:
         pass
 

--- a/jcloud/parsers/__init__.py
+++ b/jcloud/parsers/__init__.py
@@ -1,4 +1,4 @@
-def get_main_parser():
+def get_main_parser(parser=None):
     """The main parser for Jina
 
     :return: the parser
@@ -11,7 +11,7 @@ def get_main_parser():
     from .remove import set_remove_parser
 
     # create the top-level parser
-    parser = set_base_parser()
+    parser = set_base_parser(parser=parser)
 
     sp = parser.add_subparsers(
         dest='cli',

--- a/jcloud/parsers/__init__.py
+++ b/jcloud/parsers/__init__.py
@@ -14,7 +14,7 @@ def get_main_parser(parser=None):
     parser = set_base_parser(parser=parser)
 
     sp = parser.add_subparsers(
-        dest='cli',
+        dest='jc_cli',
         required=True,
     )
 

--- a/jcloud/parsers/base.py
+++ b/jcloud/parsers/base.py
@@ -1,16 +1,17 @@
 import argparse
 
 
-def set_base_parser():
+def set_base_parser(parser=None):
     import os
 
     from .. import __version__
     from .helper import _chf, colored
 
-    parser = argparse.ArgumentParser(
-        description=f'JCloud (v{colored(__version__, "green")}) deploys your Jina Flow to the cloud.',
-        formatter_class=_chf,
-    )
+    if not parser:
+        parser = argparse.ArgumentParser(
+            description=f'JCloud (v{colored(__version__, "green")}) deploys your Jina Flow to the cloud.',
+            formatter_class=_chf,
+        )
     parser.add_argument(
         '-v',
         '--version',


### PR DESCRIPTION
**Goal**
- Should allow jina to extend its own CLI with jcloud cli
- [ ] Run [Integration tests GHA](https://github.com/jina-ai/jcloud/actions/workflows/integration-tests.yml) manually & comment the link.

@jina-ai/team-wolf 
