### PR TITLE
feat: changes to accommodate the monitoring changes

### DIFF
--- a/jcloud/api.py
+++ b/jcloud/api.py
@@ -5,6 +5,7 @@ from functools import wraps
 
 from .constants import Status
 from .flow import CloudFlow, _terminate_flow_simplified
+from .helper import prepare_flow_model_for_render
 
 
 def asyncify(f):
@@ -45,6 +46,7 @@ async def status(args):
                 f'[red]Something went wrong while fetching the details for {args.flow} ![/red]. Please retry after sometime.'
             )
         else:
+            prepare_flow_model_for_render(_result)
             for k, v in _result.items():
                 if k == 'yaml' and v is not None:
                     v = Syntax(

--- a/jcloud/flow.py
+++ b/jcloud/flow.py
@@ -17,7 +17,6 @@ from .helper import (
     get_logger,
     get_or_reuse_loop,
     get_pbar,
-    prepare_flow_model_for_render,
     normalized,
     zipdir,
 )
@@ -213,7 +212,6 @@ class CloudFlow:
                 ) as response:
                     response.raise_for_status()
                     _results = await response.json()
-                    prepare_flow_model_for_render(_results)
                     return _results
         except aiohttp.ClientResponseError as e:
             if e.status == HTTPStatus.UNAUTHORIZED:

--- a/jcloud/helper.py
+++ b/jcloud/helper.py
@@ -211,10 +211,8 @@ def prepare_flow_model_for_render(response: Dict) -> None:
     elif response['endpoints']:
         del response['gateway']
 
+    # Extra handle for 'dashboards' key; the value is a map
+    # but since we only have monitoring dashboard at the moment,
+    # for simplicity we turn the map to a string for display purpose.
     if response['dashboards']:
-        # Extra handle for 'dashboards' key; the value is a map
-        # but since we only have monitoring dashboard at the moment,
-        # for simplicity we turn the map to a string for display purpose.
         response['dashboards'] = response['dashboards']['monitoring']
-    else:
-        del response['dashboards']

--- a/tests/integration/flows/executors-autoscaled.yml
+++ b/tests/integration/flows/executors-autoscaled.yml
@@ -1,7 +1,6 @@
 jtype: Flow
 with:
   protocol: http
-  monitoring: true
 jcloud:
   gateway:
     ingress: kong

--- a/tests/unit/test_helper.py
+++ b/tests/unit/test_helper.py
@@ -50,13 +50,9 @@ def test_not_normalized(filename, envs):
             {
                 'endpoints': 'something_can_be_ignored',
                 'gateway': 'abc',
-                'dashboards': None,
+                'dashboards': {'monitoring': 'abc'},
             },
-            {'gateway': 'abc'},
-        ),
-        (
-            {'endpoints': 'abc', 'gateway': None, 'dashboards': None},
-            {'endpoints': 'abc'},
+            {'gateway': 'abc', 'dashboards': 'abc'},
         ),
         (
             {


### PR DESCRIPTION
2nd attempt after #73 

Previously the tests were broken because changes in `prepare_flow_model_for_render`  breaks `_fetch_until` , as it invokes `prepare_flow_model_for_render` during `self.status`. And before the deployment is done, `dashboards` key is not in `response`.

This PR moves `prepare_flow_model_for_render` to `api.status` to avoid it (`_fetch_until` doesn't need to `prepare_flow_model_for_render` anyway, the latter is only for formatting the JSON result to be ready for UI rendering )

Tests (passed):  https://github.com/jina-ai/jcloud/actions/runs/2916228663
