### PR TITLE
fix(ci): install jina for normalize tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,6 @@ jobs:
       - name: Test basic import
         run: python -c 'import jcloud'
 
-
   prep-testbed:
     runs-on: ubuntu-latest
     needs: [commit-lint, lint-flake-8, check-black, import-test]
@@ -109,7 +108,6 @@ jobs:
           echo "::set-output name=matrix::$(bash scripts/get-all-test-paths.sh unit)"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-
 
   core-test:
     needs: prep-testbed
@@ -129,6 +127,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install wheel
+          python -m pip install jina
           export JCLOUD_LOGLEVEL=DEBUG
           pip install --no-cache-dir ".[full,test]"
           sudo apt-get install libsndfile1


### PR DESCRIPTION
**Goal**

Installs jina which is required for normalize unit tests.

- [ ] Run [Integration tests GHA](https://github.com/jina-ai/jcloud/actions/workflows/integration-tests.yml) manually & comment the link.

@jina-ai/team-wolf 
