### PR TITLE
fix: surface the max flow allowed error

### DIFF
--- a/jcloud/flow.py
+++ b/jcloud/flow.py
@@ -39,14 +39,16 @@ def _exit_if_response_error(
     response: aiohttp.ClientResponse, expected_status, json_response
 ):
     if response.status != expected_status:
-        logger.debug(f'Error Messagge: {json_response.get("error")}')
-        if response.status == HTTPStatus.FORBIDDEN:
-            if 'max number of alive flows' in json_response.get('error', ''):
-                _exit_error(
-                    f'You have reached max number of alive flows allowed: "{json_response["error"]}". Please clean up your Flow inventory.'
-                )
+        if response.status == HTTPStatus.UNAUTHORIZED:
             _exit_error(
                 'You are not logged in, please login using [b]jcloud login[/b] first.'
+            )
+        elif response.status == HTTPStatus.FORBIDDEN:
+            print(
+                f'Got an error from the server: [red]{json_response.get("error")}[/red]'
+            )
+            _exit_error(
+                f'You have exceeded your quota. Please clean up your Flow inventory.'
             )
         else:
             _exit_error(

--- a/jcloud/flow.py
+++ b/jcloud/flow.py
@@ -40,6 +40,10 @@ def _exit_if_response_error(
 ):
     if response.status != expected_status:
         if response.status == HTTPStatus.FORBIDDEN:
+            if 'max number of alive flows' in json_response.get('error', ''):
+                _exit_error(
+                    f'You have reached max number of alive flows allowed: "{json_response["error"]}". Please clean up your Flow inventory.'
+                )
             _exit_error(
                 'You are not logged in, please login using [b]jcloud login[/b] first.'
             )

--- a/jcloud/flow.py
+++ b/jcloud/flow.py
@@ -39,6 +39,7 @@ def _exit_if_response_error(
     response: aiohttp.ClientResponse, expected_status, json_response
 ):
     if response.status != expected_status:
+        logger.debug(f'Error Messagge: {json_response.get("error")}')
         if response.status == HTTPStatus.FORBIDDEN:
             if 'max number of alive flows' in json_response.get('error', ''):
                 _exit_error(


### PR DESCRIPTION
**Goal**
<img width="1004" alt="Screenshot 2022-11-24 at 10 18 16" src="https://user-images.githubusercontent.com/2687065/203679721-06a62088-613d-47a0-bf63-7082fed4439d.png">
We need to show the actual message if a user reaches the max Flows allowed otherwise it's misleading


- [ ] Run [Integration tests GHA](https://github.com/jina-ai/jcloud/actions/workflows/integration-tests.yml) manually & comment the link.

@jina-ai/team-wolf 
