### PR TITLE
refactor: show flow deployment logs url

### DIFF
--- a/jcloud/helper.py
+++ b/jcloud/helper.py
@@ -245,3 +245,13 @@ def cleanup_dt(dt) -> str:
 def get_dashboard_from_flowid(flow_id: str) -> str:
     ns = flow_id.split('-')[-1]
     return f'https://dashboard.wolf.jina.ai/flow/{ns}'
+
+
+def jcloud_logs_from_response(flow_id: str, response: Dict) -> str:
+    if 'jcloud' not in response:
+        return get_dashboard_from_flowid(flow_id)
+    else:
+        try:
+            return response['jcloud']['url']
+        except KeyError:
+            return get_dashboard_from_flowid(flow_id)


### PR DESCRIPTION
**Goal**

Pointing the user to the Flow deployment logs panel directly

![image](https://user-images.githubusercontent.com/9050737/205231859-85bc1446-0ae7-433d-82a7-a13967d34113.png)


- [x] Run [Integration tests GHA](https://github.com/jina-ai/jcloud/actions/workflows/integration-tests.yml) manually & comment the link :point_right: https://github.com/jina-ai/jcloud/actions/runs/3599529014

@jina-ai/team-wolf 
