### PR TITLE
fix: handle the validation for serverless

### DIFF
--- a/jcloud/helper.py
+++ b/jcloud/helper.py
@@ -8,6 +8,7 @@ import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Union
+from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 import pkg_resources
@@ -146,6 +147,21 @@ def get_pbar(description, disable=False, total=4):
     return pbar, pb_task
 
 
+def is_valid_serverless_uri(uses):
+    """Check to see if the 'uses' is a valid serverless URI.
+
+    Serverless notation is JCloud specific, which we need to handle in addition to
+    what Hubble already provides for URI validation.
+    """
+    try:
+        return urlparse(uses).scheme in (
+            'jinahub+serverless',
+            'jinaai+serverless',
+        )
+    except Exception:
+        return False
+
+
 def normalized(path: Union[str, Path]):
     _normalized = True
 
@@ -159,7 +175,11 @@ def normalized(path: Union[str, Path]):
             uses = executor.get('uses', None)
             if uses is None:
                 continue
-            elif is_valid_docker_uri(uses) or is_valid_sandbox_uri(uses):
+            elif (
+                is_valid_docker_uri(uses)
+                or is_valid_sandbox_uri(uses)
+                or is_valid_serverless_uri(uses)
+            ):
                 continue
             else:
                 _normalized = False

--- a/tests/unit/flows/normalized_flows/flow2.yml
+++ b/tests/unit/flows/normalized_flows/flow2.yml
@@ -4,3 +4,5 @@ executors:
     uses: jinaai+docker://ABC/hello
   - name: DEF
     uses: jinaai+sandbox://DEF/hello
+  - name: XYZ
+    uses: jinaai+serverless://XYZ/hello


### PR DESCRIPTION
**Goal**
serverless support was removed by https://github.com/jina-ai/jcloud/pull/103/files.

This syntax is something that's specific to us not Hubble, so we need to handle that in addition to what Hubble has been already doing. Otherwise we would have validation error.

I verified that it's now working locally after the patch.


- [ ] Run [Integration tests GHA](https://github.com/jina-ai/jcloud/actions/workflows/integration-tests.yml) manually & comment the link.

@jina-ai/team-wolf 
