### PR TITLE
fix: fix the bug when output argument is a file

### DIFF
--- a/jcloud/normalize.py
+++ b/jcloud/normalize.py
@@ -318,7 +318,7 @@ def flow_normalize(
     if output_path is not None:
         if isinstance(output_path, str):
             output_path = Path(output_path)
-        if output_path.suffix == '.yml':
+        if output_path.suffix.lower() in ('.yml', '.yaml'):
             output_flow_file = output_path.name
             output_path = output_path.parent
         normed_flow_path = output_path

--- a/jcloud/normalize.py
+++ b/jcloud/normalize.py
@@ -318,7 +318,7 @@ def flow_normalize(
     if output_path is not None:
         if isinstance(output_path, str):
             output_path = Path(output_path)
-        if output_path.is_file():
+        if output_path.suffix == '.yml':
             output_flow_file = output_path.name
             output_path = output_path.parent
         normed_flow_path = output_path

--- a/tests/unit/test_normalize.py
+++ b/tests/unit/test_normalize.py
@@ -111,7 +111,10 @@ def test_mixed_normalize_flow(mixed_flow_path):
     assert flow_data['executors'][1]['uses'] == 'jinahub+docker://Sentencizer'
 
 
-def test_flow_normalize_with_output_path(mixed_flow_path, tmp_path):
+def test_flow_normalize_with_output_path(mocker, mixed_flow_path, tmp_path):
+    mocker.patch('jcloud.normalize.push_executors_to_hubble')
     for output_path in [None, tmp_path, tmp_path / 'hello.yml']:
         fn = flow_normalize(mixed_flow_path / 'flow.yml', output_path=output_path)
-        assert os.path.exists(fn)
+        assert os.path.isfile(fn)
+        if output_path is not None and output_path.suffix == '.yml':
+            assert os.path.isfile(output_path)


### PR DESCRIPTION
**Goal**
resolve the bug when the output argument of  is a file. `jc normalize -o foo.yml flow.yml` will output to
`foo.yml/flow.yml`.

- [x] Run [Integration tests GHA](https://github.com/jina-ai/jcloud/actions/workflows/integration-tests.yml) manually & comment the link :point_right: https://github.com/jina-ai/jcloud/actions/runs/4053779861

@jina-ai/team-wolf 
