### PR TITLE
fix: list & remove serving & failed flows

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -30,6 +30,7 @@ jobs:
     env:
       JINA_AUTH_TOKEN: ${{ secrets.JCLOUD_INTEGRATION_TESTS_TOKEN }}
     strategy:
+      max-parallel: 25
       fail-fast: false
       matrix:
         python-version: [3.7]

--- a/jcloud/api.py
+++ b/jcloud/api.py
@@ -205,11 +205,11 @@ async def remove(args):
 
         flow_id_list = args.flows
 
-    # Case 3: remove all ALIVE and FAILED flows.
+    # Case 3: remove all SERVING and FAILED flows.
     else:
         if 'JCLOUD_NO_INTERACTIVE' not in os.environ:
             confirm_deleting_all = Confirm.ask(
-                f'[red]Are you sure you want to delete ALL the ALIVE and FAILED flows that belong to you?[/red]',
+                f'[red]Are you sure you want to delete ALL the SERVING and FAILED flows that belong to you?[/red]',
                 default=True,
             )
             if not confirm_deleting_all:

--- a/jcloud/api.py
+++ b/jcloud/api.py
@@ -151,8 +151,8 @@ async def _list_by_phase(phase: str, name: str):
     )
 
     console = Console(highlighter=CustomHighlighter())
-    if not phase:
-        phase = f'{Phase.Serving.value},{Phase.Failed.value}'
+    if phase is None:
+        phase = ','.join([str(Phase.Serving.value), str(Phase.Failed.value)])
     phases = phase.split(',')
     msg = f'[bold]Fetching [green]{phases[0] if len(phases) == 1 else " and ".join(phases)}[/green] flows'
     if name:
@@ -216,7 +216,9 @@ async def remove(args):
                 print('[cyan]No worries. Exiting...[/cyan]')
                 return
 
-        _raw_list = await _list_by_phase(phase=None, name='')
+        _raw_list = await _list_by_phase(
+            phase=','.join([str(Phase.Serving.value), str(Phase.Failed.value)]), name=''
+        )
         print('Above are the flows about to be deleted.\n')
 
         if 'JCLOUD_NO_INTERACTIVE' not in os.environ:

--- a/jcloud/flow.py
+++ b/jcloud/flow.py
@@ -384,7 +384,6 @@ class CloudFlow:
                     _args['params'].update({'phase': phase})
                 if name is not None:
                     _args['params'].update({'name': name})
-
                 async with session.get(**_args) as response:
                     response.raise_for_status()
                     _results = await response.json()

--- a/jcloud/normalize.py
+++ b/jcloud/normalize.py
@@ -289,7 +289,7 @@ def flow_normalize(
 
     flow_file_in_path = path.is_file()
 
-    if path.is_file():
+    if flow_file_in_path:
         flow_file = path.name
         path = path.parent
 
@@ -337,7 +337,7 @@ def flow_normalize(
     else:
         cm = tempfile.NamedTemporaryFile(
             'w',
-            prefix=f'{flow_file.strip(".yml") if flow_file_in_path else CONSTANTS.DEFAULT_FLOW_FILENAME.strip(".yml")}-',
+            prefix=f'{output_flow_file.strip(".yml")}-',
             suffix='.yml',
             dir=normed_flow_path,
             delete=False,

--- a/jcloud/parsers/list.py
+++ b/jcloud/parsers/list.py
@@ -10,7 +10,6 @@ def set_list_parser(parser=None):
     parser.add_argument(
         '--phase',
         type=str.title,
-        default=Phase.Serving.value,
         choices=[s.value for s in Phase] + ['All'],
         help='Pass the phase of Flows to be listed.',
     )

--- a/jcloud/parsers/remove.py
+++ b/jcloud/parsers/remove.py
@@ -10,6 +10,6 @@ def set_remove_parser(parser=None):
         nargs="*",
         help='The string ID of a flow for single removal, '
         'or a list of space seperated string IDs for multiple removal, '
-        'or string \'all\' for deleting ALL ALIVE flows.',
+        'or string \'all\' for deleting ALL SERVING flows.',
     )
     return parser


### PR DESCRIPTION
**Goal**

Fixes https://github.com/jina-ai/jina-operator/issues/279

Changes the behaviour of:

* `jc list` where if no value is passed all flows that are in `Serving` or `Failed` phase are listed
* `jc remove` where if `all` is passed all flows that are in `Serving` or `Failed` phase are deleted

- [x] Run [Integration tests GHA](https://github.com/jina-ai/jcloud/actions/workflows/integration-tests.yml) manually & comment the link. https://github.com/jina-ai/jcloud/actions/runs/4073939574

`jc list`
![image](https://user-images.githubusercontent.com/9141826/216297418-42da4151-17fe-40eb-93e1-5273735635ef.png)

`jc remove`
![image](https://user-images.githubusercontent.com/9141826/216297704-896b9e3d-bbdf-4d9b-b2a5-f90ead9e9b9d.png)

Flows are removed
![image](https://user-images.githubusercontent.com/9141826/216297770-fe0057b1-2104-443d-b84b-2a993da720b0.png)

@jina-ai/team-wolf 
