### PR TITLE
fix(list): change default phases in jc list

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -30,7 +30,7 @@ jobs:
     env:
       JINA_AUTH_TOKEN: ${{ secrets.JCLOUD_INTEGRATION_TESTS_TOKEN }}
     strategy:
-      max-parallel: 25
+      max-parallel: 10
       fail-fast: false
       matrix:
         python-version: [3.7]

--- a/jcloud/api.py
+++ b/jcloud/api.py
@@ -151,10 +151,22 @@ async def _list_by_phase(phase: str, name: str):
     )
 
     console = Console(highlighter=CustomHighlighter())
+
+    # If no phase is passed, show all flows that are not in `Deleted` phase
     if phase is None:
-        phase = ','.join([str(Phase.Serving.value), str(Phase.Failed.value)])
+        phase_to_str = lambda phase: str(phase.value)
+        phase = ','.join(
+            [
+                phase_to_str(Phase.Starting),
+                phase_to_str(Phase.Serving),
+                phase_to_str(Phase.Failed),
+                phase_to_str(Phase.Updating),
+                phase_to_str(Phase.Paused),
+            ]
+        )
+
     phases = phase.split(',')
-    msg = f'[bold]Fetching [green]{phases[0] if len(phases) == 1 else " and ".join(phases)}[/green] flows'
+    msg = f'[bold]Fetching [green]{phases[0] if len(phases) == 1 else ", ".join(phases)}[/green] flows'
     if name:
         msg += f' with name [green]{name}[/green]'
     msg += ' ...'


### PR DESCRIPTION
**Goal**

`jc list` only shows `Serving` & `Failed` Flows, unlike JAC which shows all Flows except `Deleted` ones.

![image](https://user-images.githubusercontent.com/9050737/220894717-c1044feb-8e78-484e-bb85-92130194875b.png)


![image](https://user-images.githubusercontent.com/9050737/220894430-abd55a71-bfd9-4a64-809d-dc59531a28af.png)

![image](https://user-images.githubusercontent.com/9050737/220894523-543ff02b-79e4-4643-945b-e34603cf9f5e.png)


- [x] Run [Integration tests GHA](https://github.com/jina-ai/jcloud/actions/workflows/integration-tests.yml) manually & comment the link :point_right: https://github.com/jina-ai/jcloud/actions/runs/4252196908 :heavy_check_mark: 

@jina-ai/team-wolf 
