### PR TITLE
fix: add phase to intermediate phases

### DIFF
--- a/jcloud/api.py
+++ b/jcloud/api.py
@@ -263,10 +263,10 @@ async def remove(args):
 
         flow_id_list = [flow['id'] for flow in _raw_list['flows']]
 
-    await _remove_multi(flow_id_list)
+    await _remove_multi(flow_id_list, args.phase)
 
 
-async def _remove_multi(flow_id_list):
+async def _remove_multi(flow_id_list, phase):
     from rich import print
 
     from .helper import get_pbar
@@ -284,7 +284,7 @@ async def _remove_multi(flow_id_list):
             title=f'Removing {num_flows_to_remove} flows...',
         )
 
-        coros = [_terminate_flow_simplified(flow) for flow in flow_id_list]
+        coros = [_terminate_flow_simplified(flow, phase) for flow in flow_id_list]
         counter = 0
         has_failure_task = False
         for coro in asyncio.as_completed(coros):

--- a/jcloud/flow.py
+++ b/jcloud/flow.py
@@ -547,7 +547,7 @@ class CloudFlow:
         yield Panel(my_table, title=f':tada: Flow is {self.flow_status}!', expand=False)
 
 
-async def _terminate_flow_simplified(flow_id):
+async def _terminate_flow_simplified(flow_id, phase):
     """Terminate a Flow given flow_id.
 
     This is a simplified version of CloudFlow.__aexit__, i.e.,
@@ -558,7 +558,7 @@ async def _terminate_flow_simplified(flow_id):
     flow = CloudFlow(flow_id=flow_id)
     await flow._terminate()
     await flow._fetch_until(
-        intermediate=[Phase.Serving],
+        intermediate=[Phase.Serving, phase],
         desired=Phase.Deleted,
     )
 

--- a/jcloud/flow.py
+++ b/jcloud/flow.py
@@ -547,7 +547,7 @@ class CloudFlow:
         yield Panel(my_table, title=f':tada: Flow is {self.flow_status}!', expand=False)
 
 
-async def _terminate_flow_simplified(flow_id, phase):
+async def _terminate_flow_simplified(flow_id: str, phase: Optional[str] = None):
     """Terminate a Flow given flow_id.
 
     This is a simplified version of CloudFlow.__aexit__, i.e.,
@@ -557,8 +557,11 @@ async def _terminate_flow_simplified(flow_id, phase):
 
     flow = CloudFlow(flow_id=flow_id)
     await flow._terminate()
+    _intermediate_phases = [Phase.Serving]
+    if phase is not None:
+        _intermediate_phases.append(phase)
     await flow._fetch_until(
-        intermediate=[Phase.Serving, phase],
+        intermediate=_intermediate_phases,
         desired=Phase.Deleted,
     )
 

--- a/tests/integration/remove_multiple/test_multi_flows_removal.py
+++ b/tests/integration/remove_multiple/test_multi_flows_removal.py
@@ -60,7 +60,7 @@ async def test_remove_selected_flows():
     assert added_flows.issubset(owned_flows_after_add)
 
     logger.info(f'Removing two new flows...')
-    await _remove_multi(list(added_flows))
+    await _remove_multi(list(added_flows), None)
 
     owned_flows_after_delete = await get_serving_flows()
     logger.info(f'Owned flows after removal: {len(owned_flows_after_delete)}')

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -71,10 +71,10 @@ def test_remove_by_phase(mock_list_by_phase, mock_terminate_flow_simplified, moc
     remove(args)
     mock_terminate_flow_simplified.assert_has_calls(
         [
-            call('flow_1'),
-            call('workable-shrew-f1bdd8f74b'),
-            call('firm-condor-77f454eac2'),
-            call('somename-1234567890'),
+            call('flow_1', 'Serving'),
+            call('workable-shrew-f1bdd8f74b', args.phase),
+            call('firm-condor-77f454eac2', args.phase),
+            call('somename-1234567890', args.phase),
         ],
         any_order=True,
     )
@@ -93,7 +93,9 @@ def test_remove_selected_multi(
     mock_terminate_flow_simplified.side_effect = mock_terminate
 
     remove(args)
-    mock_terminate_flow_simplified.assert_has_calls([call('flow_1'), call('flow_2')])
+    mock_terminate_flow_simplified.assert_has_calls(
+        [call('flow_1', args.phase), call('flow_2', args.phase)]
+    )
 
 
 @patch('rich.prompt.Confirm.ask', return_value=True)
@@ -110,9 +112,9 @@ def test_remove_all(mock_list_by_phase, mock_terminate_flow_simplified, mock_ask
 
     mock_terminate_flow_simplified.assert_has_calls(
         [
-            call('firm-condor-77f454eac2'),
-            call('workable-shrew-f1bdd8f74b'),
-            call('somename-1234567890'),
+            call('firm-condor-77f454eac2', args.phase),
+            call('workable-shrew-f1bdd8f74b', args.phase),
+            call('somename-1234567890', args.phase),
         ]
     )
 
@@ -130,9 +132,9 @@ def test_non_interative(mock_list_by_phase, mock_terminate_flow_simplified):
     remove(args)
     mock_terminate_flow_simplified.assert_has_calls(
         [
-            call('firm-condor-77f454eac2'),
-            call('workable-shrew-f1bdd8f74b'),
-            call('somename-1234567890'),
+            call('firm-condor-77f454eac2', args.phase),
+            call('workable-shrew-f1bdd8f74b', args.phase),
+            call('somename-1234567890', args.phase),
         ]
     )
 


### PR DESCRIPTION
**Goal**

Attempts to fix issue with this [test](https://github.com/jina-ai/jcloud/actions/runs/4475421846/jobs/7864828339).

It adds the phase as an optional parameter to `_terminate_flow_simplified()` to avoid failing on intermediate flow status checks.

- [x] Run [Integration tests GHA](https://github.com/jina-ai/jcloud/actions/workflows/integration-tests.yml) manually & comment the link. https://github.com/jina-ai/jcloud/actions/runs/4479348517

@jina-ai/team-wolf 
