### PR TITLE
fix: adding env vars for normalized flows

### DIFF
--- a/jcloud/flow.py
+++ b/jcloud/flow.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import yaml
 import os
 from contextlib import suppress
 from dataclasses import dataclass
@@ -22,7 +23,7 @@ from .helper import (
     jcloud_logs_from_response,
     normalized,
 )
-from .normalize import validate_flow_yaml_exists
+from .normalize import get_filename_envs, validate_flow_yaml_exists, load_flow_data
 
 logger = get_logger()
 
@@ -96,10 +97,14 @@ class CloudFlow:
             _flow_path = _flow_path / 'flow.yml'
 
         validate_flow_yaml_exists(_flow_path)
-
         if not normalized(_flow_path):
             _flow_path = flow_normalize(_flow_path)
-        _data.add_field(name='spec', value=open(_flow_path))
+            _data.add_field(name='spec', value=open(_flow_path))
+        else:
+            _flow_dict = load_flow_data(
+                _flow_path, get_filename_envs(_flow_path.parent)
+            )
+            _data.add_field(name='spec', value=yaml.dump(_flow_dict).encode())
 
         if _data._fields:
             _post_kwargs['data'] = _data

--- a/tests/integration/normalized_flow_env_vars/flow.yml
+++ b/tests/integration/normalized_flow_env_vars/flow.yml
@@ -1,0 +1,5 @@
+jtype: Flow
+executors:
+  - uses: jinaai+docker://auth0-unified-64c3e19b1d2f398f/JCloudCISentencizer:latest
+    env:
+      TEST: ${{ ENV.TEST }}

--- a/tests/integration/normalized_flow_env_vars/test_normalized_flow_env_vars.py
+++ b/tests/integration/normalized_flow_env_vars/test_normalized_flow_env_vars.py
@@ -1,0 +1,33 @@
+import os
+
+from jina import Client, Document, DocumentArray
+
+from jcloud.flow import CloudFlow
+
+from jcloud.helper import get_dict_list_key_path
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+flow_file = 'flow.yml'
+protocol = 'grpc'
+
+
+def test_update_executor_args():
+    os.environ["TEST"] = "test"
+    with CloudFlow(path=os.path.join(cur_dir, flow_file)) as flow:
+
+        assert flow.endpoints != {}
+        assert 'gateway' in flow.endpoints
+        gateway = flow.endpoints['gateway']
+        assert gateway.startswith(f'{protocol}s://')
+
+        status = flow._loop.run_until_complete(flow.status)
+        assert (
+            get_dict_list_key_path(status, ['spec', 'executors', 0, 'env', 'TEST'])
+            == 'test'
+        )
+
+        da = Client(host=gateway).post(
+            on='/',
+            inputs=DocumentArray(Document(text=f'text-{i}') for i in range(50)),
+        )
+        assert len(da.texts) == 50

--- a/tests/integration/update/test_update_executor_args.py
+++ b/tests/integration/update/test_update_executor_args.py
@@ -35,12 +35,11 @@ def test_update_executor_args():
         assert gateway.startswith(f'{protocol}s://')
 
         status = flow._loop.run_until_complete(flow.status)
-
         assert (
             get_dict_list_key_path(
                 status, ['spec', 'executors', 0, 'uses_with', 'punct_chars']
             )
-            == '${{ ENV.PUNCT_CHARS }}'
+            == '$PUNCT_CHARS'
         )
 
         da = Client(host=gateway).post(


### PR DESCRIPTION
**Goal**

- Closes #141 

### Normalised flow
```yaml
jtype: Flow
with:
  protocol: http
  name: test-flow
  env:
    TEST_ENV_VAR: ${{ ENV.VAR }}
executors:
  - uses: jinaai+docker://auth0-unified-64c3e19b1d2f398f/JCloudCISentencizer:latest
```

Deploying flow with `env` var in environment
![image](https://user-images.githubusercontent.com/9141826/234930582-56eeebdf-fdc8-4e0e-a29b-1cc0c5828654.png)
![image](https://user-images.githubusercontent.com/9141826/234930776-a82e0c54-08f9-4e39-96f9-ca236754e425.png)
![image](https://user-images.githubusercontent.com/9141826/234930799-7e349e12-daa1-4922-8776-30812db9859e.png)

- [x] Run [Integration tests GHA](https://github.com/jina-ai/jcloud/actions/workflows/integration-tests.yml) manually & comment the link. https://github.com/jina-ai/jcloud/actions/runs/4828329259

@jina-ai/team-wolf 