### PR TITLE
fix: parse jcloud labels as str

### DIFF
--- a/jcloud/flow.py
+++ b/jcloud/flow.py
@@ -221,7 +221,8 @@ class CloudFlow:
                 ],
                 desired=desired_phase,
             )
-            pbar.console.print(self)
+            if 'JCLOUD_HIDE_SUCCESS_MSG' not in os.environ:
+                pbar.console.print(self)
             pbar.update(pb_task, description='Finishing', advance=1)
 
     async def custom_action(

--- a/jcloud/flow.py
+++ b/jcloud/flow.py
@@ -115,7 +115,9 @@ class CloudFlow:
             _flow_dict = load_flow_data(
                 _flow_path, get_filename_envs(_flow_path.parent)
             )
-            _data.add_field(name='spec', value=yaml.dump(_flow_dict).encode())
+            _data.add_field(
+                name='spec', value=yaml.dump(_flow_dict, sort_keys=False).encode()
+            )
 
         if _data._fields:
             _post_kwargs['data'] = _data

--- a/jcloud/normalize.py
+++ b/jcloud/normalize.py
@@ -38,6 +38,30 @@ class ExecutorData:
 class FlowYamlNotFound(FileNotFoundError):
     pass
 
+def stringify(v: Any) -> str:
+    if isinstance(v, str):
+        return v
+    elif isinstance(v, int) or isinstance(v, float):
+        return str(v)
+
+
+def stringify_labels(flow_dict: Dict) -> Dict:
+    global_jcloud_labels = flow_dict.get('jcloud', {}).get('labels', None)
+    if global_jcloud_labels:
+        for k, v in flow_dict['jcloud']['labels'].items():
+            flow_dict['jcloud']['labels'][k] = stringify(v)
+    gateway_jcloud_labels = flow_dict.get('gateway', {}).get('jcloud', {}).get('labels', None)
+    if gateway_jcloud_labels:
+        for k, v in flow_dict['gateway']['jcloud']['labels'].items():
+            flow_dict['gateway']['jcloud']['labels'][k] = stringify(v)
+    
+    for idx in range(len(flow_dict['executors'])):
+        executor_jcloud_labels = flow_dict['executors'][idx].get('jcloud', {}).get('labels', None)
+        if executor_jcloud_labels:
+            for k, v in flow_dict['executors'][idx]['jcloud']['labels'].items():
+                flow_dict['executors'][idx]['jcloud']['labels'][k] = stringify(v)
+    return flow_dict
+
 
 def get_hubble_uses(executor: 'ExecutorData') -> str:
     if executor.id is not None:
@@ -149,6 +173,7 @@ def load_flow_data(path: Union[str, Path], envs: Optional[Dict] = None) -> Dict:
         flow_dict = JAML.load(f, substitute=True, context=envs)
         if 'jtype' not in flow_dict or flow_dict['jtype'] != 'Flow':
             raise ValueError(f'The file `{path}` is not a valid Flow YAML')
+        flow_dict = stringify_labels(flow_dict)
         return flow_dict
 
 

--- a/jcloud/normalize.py
+++ b/jcloud/normalize.py
@@ -38,6 +38,7 @@ class ExecutorData:
 class FlowYamlNotFound(FileNotFoundError):
     pass
 
+
 def stringify(v: Any) -> str:
     if isinstance(v, str):
         return v
@@ -50,13 +51,17 @@ def stringify_labels(flow_dict: Dict) -> Dict:
     if global_jcloud_labels:
         for k, v in flow_dict['jcloud']['labels'].items():
             flow_dict['jcloud']['labels'][k] = stringify(v)
-    gateway_jcloud_labels = flow_dict.get('gateway', {}).get('jcloud', {}).get('labels', None)
+    gateway_jcloud_labels = (
+        flow_dict.get('gateway', {}).get('jcloud', {}).get('labels', None)
+    )
     if gateway_jcloud_labels:
         for k, v in flow_dict['gateway']['jcloud']['labels'].items():
             flow_dict['gateway']['jcloud']['labels'][k] = stringify(v)
-    
+
     for idx in range(len(flow_dict['executors'])):
-        executor_jcloud_labels = flow_dict['executors'][idx].get('jcloud', {}).get('labels', None)
+        executor_jcloud_labels = (
+            flow_dict['executors'][idx].get('jcloud', {}).get('labels', None)
+        )
         if executor_jcloud_labels:
             for k, v in flow_dict['executors'][idx]['jcloud']['labels'].items():
                 flow_dict['executors'][idx]['jcloud']['labels'][k] = stringify(v)

--- a/jcloud/normalize.py
+++ b/jcloud/normalize.py
@@ -39,11 +39,17 @@ class FlowYamlNotFound(FileNotFoundError):
     pass
 
 
+class JCloudLabelsError(TypeError):
+    pass
+
+
 def stringify(v: Any) -> str:
     if isinstance(v, str):
         return v
     elif isinstance(v, int) or isinstance(v, float):
         return str(v)
+    else:
+        raise JCloudLabelsError(f'labels can\'t be of type {type(v)}')
 
 
 def stringify_labels(flow_dict: Dict) -> Dict:

--- a/jcloud/normalize.py
+++ b/jcloud/normalize.py
@@ -58,7 +58,8 @@ def stringify_labels(flow_dict: Dict) -> Dict:
         for k, v in flow_dict['gateway']['jcloud']['labels'].items():
             flow_dict['gateway']['jcloud']['labels'][k] = stringify(v)
 
-    for idx in range(len(flow_dict['executors'])):
+    executors = flow_dict.get('executors', [])
+    for idx in range(len(executors)):
         executor_jcloud_labels = (
             flow_dict['executors'][idx].get('jcloud', {}).get('labels', None)
         )

--- a/tests/unit/flows/flow-with-labels.yml
+++ b/tests/unit/flows/flow-with-labels.yml
@@ -9,3 +9,5 @@ executors:
       labels:
         test-executor-label-one: 352
         test-executor-label-two: "hello"
+        test-label-bool: true
+        test-label-complex: 1j

--- a/tests/unit/flows/flow-with-labels.yml
+++ b/tests/unit/flows/flow-with-labels.yml
@@ -1,0 +1,11 @@
+jtype: Flow
+jcloud:
+  labels:
+    test-label-one: 1
+    test-label-two: 231
+executors:
+  - uses: jinahub+docker://Sentencizer
+    jcloud:
+      labels:
+        test-executor-label-one: 352
+        test-executor-label-two: "hello"

--- a/tests/unit/flows/flow-with-obj-label.yml
+++ b/tests/unit/flows/flow-with-obj-label.yml
@@ -1,0 +1,7 @@
+jtype: Flow
+jcloud:
+  labels:
+    test-label-invalid-obj:
+      foo: bar
+executors:
+  - uses: jinahub+docker://Sentencizer

--- a/tests/unit/test_normalize.py
+++ b/tests/unit/test_normalize.py
@@ -103,16 +103,22 @@ def test_inspect_executors_without_uses(filename, cur_dir):
     assert executors[2].hubble_url == f'jinaai/jina:{jina.__version__}-py38-standard'
 
 
-@pytest.mark.parametrize('filename', ('flow-with-labels.yml',))
+@pytest.mark.parametrize(
+    'filename', ('flow-with-labels.yml', 'flow-with-obj-label.yml')
+)
 def test_flow_labels_are_stringified(filename, cur_dir):
     flow_dir = os.path.join(cur_dir, 'flows')
-    flow_dict = load_flow_data(Path(os.path.join(flow_dir, filename)))
+    if filename == 'flow-with-obj-label.yml':
+        with pytest.raises(JCloudLabelsError) as exc_info:
+            flow_dict = load_flow_data(Path(os.path.join(flow_dir, filename)))
+            assert 'dict' in exc_info.value
+    else:
+        flow_dict = load_flow_data(Path(os.path.join(flow_dir, filename)))
+        for _, label_value in flow_dict['jcloud']['labels'].items():
+            assert isinstance(label_value, str)
 
-    for _, label_value in flow_dict['jcloud']['labels'].items():
-        assert isinstance(label_value, str)
-
-    for _, label_value in flow_dict['executors'][0]['jcloud']['labels'].items():
-        assert isinstance(label_value, str)
+        for _, label_value in flow_dict['executors'][0]['jcloud']['labels'].items():
+            assert isinstance(label_value, str)
 
 
 def test_mixed_update_flow_data(mixed_flow_path):

--- a/tests/unit/test_normalize.py
+++ b/tests/unit/test_normalize.py
@@ -103,6 +103,18 @@ def test_inspect_executors_without_uses(filename, cur_dir):
     assert executors[2].hubble_url == f'jinaai/jina:{jina.__version__}-py38-standard'
 
 
+@pytest.mark.parametrize('filename', ('flow-with-labels.yml',))
+def test_flow_labels_are_stringified(filename, cur_dir):
+    flow_dir = os.path.join(cur_dir, 'flows')
+    flow_dict = load_flow_data(Path(os.path.join(flow_dir, filename)))
+
+    for _, label_value in flow_dict['jcloud']['labels'].items():
+        assert isinstance(label_value, str)
+
+    for _, label_value in flow_dict['executors'][0]['jcloud']['labels'].items():
+        assert isinstance(label_value, str)
+
+
 def test_mixed_update_flow_data(mixed_flow_path):
     flow_data = load_flow_data(mixed_flow_path / 'flow.yml')
     executors = inspect_executors(flow_data, mixed_flow_path, '', '')


### PR DESCRIPTION
**Goal**

- Parses the flow dict loaded with `JAML.load` and converts the change types of `jcloud.labels` from an `int` to `str`

- [x] Run [Integration tests GHA](https://github.com/jina-ai/jcloud/actions/workflows/integration-tests.yml) manually & comment the link. https://github.com/jina-ai/jcloud/actions/runs/5180469639

@jina-ai/team-wolf 
