### PR TITLE
feat: check flow is valid before deployment

### DIFF
--- a/jcloud/flow.py
+++ b/jcloud/flow.py
@@ -122,7 +122,35 @@ class CloudFlow:
         _post_kwargs['params'] = params
         return _post_kwargs
 
+    async def validate(self):
+        try:
+            async with get_aiohttp_session() as session:
+                async with session.post(
+                    url=FLOWS_API + '/validate',
+                    headers=self.auth_header,
+                    **await self._get_post_params(),
+                ) as response:
+                    json_response = await response.json()
+                    response.raise_for_status()
+                    return json_response
+        except aiohttp.ClientResponseError:
+            _exit_if_response_error(
+                response,
+                expected_status=HTTPStatus.OK,
+                json_response=json_response,
+            )
+
     async def _deploy(self):
+        _validate_resposne = await self.validate()
+        if len(_validate_resposne['errors']) == 0:
+            logger.info(
+                f'Succesfully validated flow config. Proceeding to flow deployment...'
+            )
+        else:
+            errors = '\n'.join(_validate_resposne['errors'])
+            _exit_error(
+                f'Found {len(_validate_resposne["errors"])} error(s) in Flow config.\n{errors}'
+            )
         for i in range(2):
             try:
                 async with get_aiohttp_session() as session:

--- a/tests/integration/validate/flows/invalid-flow.yml
+++ b/tests/integration/validate/flows/invalid-flow.yml
@@ -1,0 +1,10 @@
+jtype: Flow
+gateway:
+  protocol: http
+executors:
+  - name: sentencizer
+    uses: jinahub+docker://Sentencizer
+    jcloud:
+      monitor:
+        traces:
+          host: 123

--- a/tests/integration/validate/flows/valid-flow.yml
+++ b/tests/integration/validate/flows/valid-flow.yml
@@ -1,0 +1,6 @@
+jtype: Flow
+with:
+  protocol: http
+executors:
+  - name: sentencizer
+    uses: jinahub+docker://Sentencizer

--- a/tests/integration/validate/test_validate.py
+++ b/tests/integration/validate/test_validate.py
@@ -1,0 +1,24 @@
+import os
+
+from jina import Client, Document, DocumentArray
+
+from jcloud.flow import CloudFlow
+
+flows_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'flows')
+valid_flow_file = 'valid-flow.yml'
+invalid_flow_file = 'invalid-flow.yml'
+
+
+async def test_valid_flow():
+    validate_response = await CloudFlow(
+        path=os.path.join(flows_dir, valid_flow_file)
+    ).validate()
+
+    assert len(validate_response['errors']) == 0
+
+
+async def test_invalid_flow():
+    validate_response = await CloudFlow(
+        path=os.path.join(flows_dir, invalid_flow_file)
+    ).validate()
+    assert len(validate_response['errors']) == 2


### PR DESCRIPTION
**Goal**

- Closes [jina-ai/jina-operator#396](https://github.com/jina-ai/jina-operator/issues/396)

- [x] Run [Integration tests GHA](https://github.com/jina-ai/jcloud/actions/workflows/integration-tests.yml) manually & comment the link. https://github.com/jina-ai/jcloud/actions/runs/5253170593

For the below `flow.yml`
```yml
jtype: Flow
gateway:
  protocol: http
executors:
  - name: sentencizer
    uses: jinahub+docker://Sentencizer
    jcloud:
      monitor:
        traces:
          host: 123
```

The output of `jc deploy flow.yml` is the following
![image](https://github.com/jina-ai/jcloud/assets/9141826/19c3d492-c7b6-457a-8a78-6e18df58e6dc)

@jina-ai/team-wolf 
